### PR TITLE
Baseline Statistical Mean Reversion research (Issue #8)

### DIFF
--- a/db/strategy_research/001_strategy_research_schema.sql
+++ b/db/strategy_research/001_strategy_research_schema.sql
@@ -1,0 +1,17 @@
+-- Migration: 001_strategy_research_schema.sql
+-- Creates the strategy_research schema and shared experiment_runs table.
+-- Idempotent: safe to run multiple times.
+
+-- Schema must be created by a superuser before running this migration.
+-- CREATE SCHEMA IF NOT EXISTS strategy_research;
+
+CREATE TABLE IF NOT EXISTS strategy_research.experiment_runs (
+    run_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    strategy_name   TEXT NOT NULL,
+    run_ts          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    config          JSONB,
+    notes           TEXT
+);
+
+COMMENT ON TABLE strategy_research.experiment_runs IS
+    'Registry of all research experiment runs across all isolated strategies.';

--- a/db/strategy_research/002_stat_mr_tables.sql
+++ b/db/strategy_research/002_stat_mr_tables.sql
@@ -1,0 +1,159 @@
+-- Migration: 002_stat_mr_tables.sql
+-- Tables for Baseline Statistical Mean Reversion (STAT_MR) research.
+-- All tables under strategy_research schema.
+-- Idempotent: safe to run multiple times.
+
+-- Features at signal-eligible bars (|z| > min threshold)
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_features (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    bar_ts          TIMESTAMPTZ NOT NULL,
+    mid_close       NUMERIC NOT NULL,
+    mean_n          NUMERIC NOT NULL,
+    std_n           NUMERIC NOT NULL,
+    z_score         NUMERIC NOT NULL,
+    period_label    TEXT NOT NULL,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, bar_ts)
+);
+
+-- Entry signal events
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_signals (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    threshold       NUMERIC NOT NULL,
+    signal_ts       TIMESTAMPTZ NOT NULL,
+    side            INT NOT NULL,         -- +1 long, -1 short
+    z_at_entry      NUMERIC NOT NULL,
+    mid_at_entry    NUMERIC NOT NULL,
+    period_label    TEXT NOT NULL,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, threshold, signal_ts, side)
+);
+
+-- Completed trades
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_trades (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    threshold       NUMERIC NOT NULL,
+    entry_ts        TIMESTAMPTZ NOT NULL,
+    exit_ts         TIMESTAMPTZ,
+    entry_price     NUMERIC NOT NULL,
+    exit_price      NUMERIC,
+    z_at_entry      NUMERIC NOT NULL,
+    z_at_exit       NUMERIC,
+    side            INT NOT NULL,
+    bars_held       INT,
+    return_pct      NUMERIC,
+    period_label    TEXT NOT NULL,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, threshold, entry_ts, side)
+);
+
+-- Aggregate metrics per (symbol, timeframe, lookback, threshold, period)
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_analysis_summary (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    threshold       NUMERIC NOT NULL,
+    period_label    TEXT NOT NULL,
+    n_trades        INT,
+    mean_return     NUMERIC,
+    median_return   NUMERIC,
+    std_return      NUMERIC,
+    sharpe          NUMERIC,
+    win_rate        NUMERIC,
+    payoff          NUMERIC,
+    cum_return      NUMERIC,
+    max_drawdown    NUMERIC,
+    avg_bars_held   NUMERIC,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, threshold, period_label)
+);
+
+-- In-sample vs unseen comparison with degradation ratios
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_period_comparison (
+    run_id              UUID NOT NULL,
+    symbol              TEXT NOT NULL,
+    timeframe           TEXT NOT NULL,
+    lookback            INT NOT NULL,
+    threshold           NUMERIC NOT NULL,
+    is_sharpe           NUMERIC,
+    oos_sharpe          NUMERIC,
+    is_mean_return      NUMERIC,
+    oos_mean_return     NUMERIC,
+    is_win_rate         NUMERIC,
+    oos_win_rate        NUMERIC,
+    is_payoff           NUMERIC,
+    oos_payoff          NUMERIC,
+    is_max_dd           NUMERIC,
+    oos_max_dd          NUMERIC,
+    sharpe_degradation  NUMERIC,
+    return_degradation  NUMERIC,
+    trade_count_ratio   NUMERIC,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, threshold)
+);
+
+-- Ranked timeframe performance per symbol
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_timeframe_comparison (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    threshold       NUMERIC NOT NULL,
+    timeframe       TEXT NOT NULL,
+    period_label    TEXT NOT NULL,
+    sharpe          NUMERIC,
+    n_trades        INT,
+    win_rate        NUMERIC,
+    tf_rank         INT,
+    PRIMARY KEY (run_id, symbol, lookback, threshold, timeframe, period_label)
+);
+
+-- Parameter grid stability
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_param_robustness (
+    run_id              UUID NOT NULL,
+    symbol              TEXT NOT NULL,
+    timeframe           TEXT NOT NULL,
+    period_label        TEXT NOT NULL,
+    lookback            INT NOT NULL,
+    threshold           NUMERIC NOT NULL,
+    sharpe              NUMERIC,
+    n_trades            INT,
+    neighbor_mean_sharpe NUMERIC,
+    stability_score     NUMERIC,
+    PRIMARY KEY (run_id, symbol, timeframe, period_label, lookback, threshold)
+);
+
+-- Subperiod performance (calendar year splits)
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_analysis_by_period (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    threshold       NUMERIC NOT NULL,
+    period_year     INT NOT NULL,
+    n_trades        INT,
+    mean_return     NUMERIC,
+    sharpe          NUMERIC,
+    win_rate        NUMERIC,
+    cum_return      NUMERIC,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, threshold, period_year)
+);
+
+-- Return distribution by z-score bucket at entry
+CREATE TABLE IF NOT EXISTS strategy_research.stat_mr_analysis_by_entry_bucket (
+    run_id          UUID NOT NULL,
+    symbol          TEXT NOT NULL,
+    timeframe       TEXT NOT NULL,
+    lookback        INT NOT NULL,
+    period_label    TEXT NOT NULL,
+    z_bucket        TEXT NOT NULL,   -- e.g. '[-3,-2.5)', '[-2.5,-2)', etc.
+    side            INT NOT NULL,
+    n_trades        INT,
+    mean_return     NUMERIC,
+    win_rate        NUMERIC,
+    PRIMARY KEY (run_id, symbol, timeframe, lookback, period_label, z_bucket, side)
+);

--- a/docs/strategies/STAT_MR_STRATEGY.md
+++ b/docs/strategies/STAT_MR_STRATEGY.md
@@ -1,0 +1,177 @@
+# Baseline Statistical Mean Reversion Strategy
+
+## Status
+
+STAT_MR is an active exploratory research strategy (Stage A).
+
+It is not frozen.
+It is not approved for live trading.
+It is not approved for advanced sizing.
+It is completely isolated from CTU, ETD, and any live trading infrastructure.
+
+STAT_MR stays in research until a new issue explicitly promotes it.
+
+---
+
+## Strategy identity
+
+STAT_MR stands for:
+
+**Baseline Statistical Mean Reversion**
+
+This is a pure baseline research object.
+
+The goal is to determine whether raw statistical mean reversion exists across timeframes and instruments before introducing any filters, regimes, or hybrid logic.
+
+The intuition is simple:
+
+- prices deviate from their rolling mean
+- normalised by local volatility (z-score), large deviations tend to revert
+- the simplest possible entry/exit captures this if the edge exists
+
+---
+
+## Exact signal definition
+
+Entry long: `z_t < -entry_threshold`
+Entry short: `z_t > +entry_threshold`
+
+Where:
+
+`z_t = (close_t - mean_N) / std_N`
+
+- `mean_N` is the rolling mean of mid close over `N` bars
+- `std_N` is the rolling standard deviation over `N` bars
+
+Exit: `z_t` crosses 0
+
+- long exits when `z_t >= 0`
+- short exits when `z_t <= 0`
+
+No stop loss beyond this rule.
+No filters.
+No volatility regime conditioning.
+No pyramiding.
+
+---
+
+## Price definition
+
+`mid_close = (bid_close + ask_close) / 2`
+
+---
+
+## Parameter grid
+
+These are the pre-declared research parameters. Do not add new values after seeing results.
+
+- `lookback ∈ {10, 20, 30}`
+- `entry_threshold ∈ {1.5, 2.0, 2.5}`
+
+Total combinations: 9 per symbol × timeframe.
+
+---
+
+## Timeframes
+
+`5m, 10m, 15m, 30m, 1h, 4h, 6h`
+
+Sub-hourly timeframes use `market_data.minute_prices`.
+Hourly+ timeframes use `market_data.hourly_prices`.
+
+---
+
+## Research split
+
+- **In-sample:** `date < 2025-06-01`
+- **Unseen:** `date >= 2025-06-01`
+
+All outputs carry `period_label ∈ {in_sample, unseen}`.
+
+The unseen split must never be touched during model selection or parameter tuning.
+
+---
+
+## Universe
+
+Symbols with full historical data in TimescaleDB:
+
+- AUD/CAD, AUD/CHF, AUD/JPY, AUD/NZD, AUD/USD (forex)
+- EUR/USD, GBP/USD, USD/JPY (forex)
+- AUS200 (global index)
+- BTC/USD, BCH/USD (crypto)
+- NGAS (energy)
+- XAU/USD (metal)
+
+Sub-hourly timeframes are restricted to this set (symbols with full minute history).
+
+---
+
+## Data source
+
+`market_data.minute_prices` — for 5m, 10m, 15m, 30m
+`market_data.hourly_prices` — for 1h, 4h, 6h
+
+All outputs written to `strategy_research` schema only.
+
+No writes to `features`, `trading_metrics_dev`, or any production schema.
+
+---
+
+## Output tables
+
+All under `strategy_research`:
+
+- `experiment_runs` — run registry with metadata
+- `stat_mr_features` — per-bar z-score features at signal bars
+- `stat_mr_signals` — all entry signal events
+- `stat_mr_trades` — all completed trades
+- `stat_mr_analysis_summary` — aggregate metrics per (symbol, timeframe, params)
+- `stat_mr_period_comparison` — IS vs unseen comparison with degradation ratios
+- `stat_mr_timeframe_comparison` — ranked timeframe performance per symbol
+- `stat_mr_param_robustness` — parameter grid stability metrics
+- `stat_mr_analysis_by_period` — subperiod performance (calendar splits)
+- `stat_mr_analysis_by_entry_bucket` — return distribution by z-score bucket at entry
+
+---
+
+## Current constants
+
+- `OOS_CUTOFF = '2025-06-01'`
+- `LOOKBACKS = [10, 20, 30]`
+- `THRESHOLDS = [1.5, 2.0, 2.5]`
+- `TIMEFRAMES = ['5min', '10min', '15min', '30min', '1h', '4h', '6h']`
+
+These belong to research configuration and must not drift without a new issue.
+
+---
+
+## Research process position
+
+Stage A — Exploratory discovery.
+
+Goal: determine whether raw statistical mean reversion exists as a signal.
+
+The strategy is not frozen.
+No filters are permitted at this stage.
+No advanced sizing.
+No comparisons to CTU or ETD.
+
+Decision to be made after full analysis:
+
+- **CONTINUE** to Stage B (candidate freeze) if edge exists robustly
+- **MONITOR** if edge is conditional or thin
+- **REJECT** if no credible signal survives unseen evaluation
+
+---
+
+## Isolation requirements
+
+This strategy MUST NOT:
+
+- share code with CTU or ETD
+- write to `features` schema or any production schema
+- use CTU/ETD parameters, thresholds, or logic
+- share DAGs or pipelines with live systems
+
+All outputs go to `strategy_research` schema only.

--- a/scripts/stat_mr/stat_mr_research.py
+++ b/scripts/stat_mr/stat_mr_research.py
@@ -1,0 +1,613 @@
+"""
+Baseline Statistical Mean Reversion Research (STAT_MR)
+=======================================================
+Issue #8 — Stage A exploratory research.
+
+Signal:  z_t = (close_t - mean_N) / std_N
+Entry:   long if z < -threshold, short if z > +threshold
+Exit:    z crosses 0
+
+Parameter grid:
+  lookback   ∈ {10, 20, 30}
+  threshold  ∈ {1.5, 2.0, 2.5}
+  timeframes: 5min, 10min, 15min, 30min, 1h, 4h, 6h
+
+Research split:
+  in_sample : date < 2025-06-01
+  unseen    : date >= 2025-06-01
+
+All outputs written to strategy_research schema only.
+"""
+
+import os
+import json
+import uuid
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+import pandas as pd
+import numpy as np
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+OOS_CUTOFF    = pd.Timestamp('2025-06-01', tz='UTC')
+LOOKBACKS     = [10, 20, 30]
+THRESHOLDS    = [1.5, 2.0, 2.5]
+FEAT_LOOKBACK = 20   # representative lookback for feature table storage
+
+TIMEFRAMES = [
+    ('5min',  '5min',  'minute'),
+    ('10min', '10min', 'minute'),
+    ('15min', '15min', 'minute'),
+    ('30min', '30min', 'minute'),
+    ('1h',    '1h',    'hourly'),
+    ('4h',    '4h',    'hourly'),
+    ('6h',    '6h',    'hourly'),
+]
+
+MINUTE_SYMBOLS = [
+    'AUD/CAD', 'AUD/CHF', 'AUD/JPY', 'AUD/NZD', 'AUD/USD',
+    'EUR/USD', 'GBP/USD', 'USD/JPY',
+    'AUS200', 'BTC/USD', 'BCH/USD', 'NGAS', 'XAU/USD',
+]
+
+# ---------------------------------------------------------------------------
+# DB
+# ---------------------------------------------------------------------------
+def connect():
+    _root = Path(__file__).resolve().parents[2]
+    load_dotenv(dotenv_path=_root / '.env')
+    dsn = os.environ.get('TIMESCALE_DSN')
+    if dsn:
+        return psycopg2.connect(dsn)
+    return psycopg2.connect(
+        host=os.environ['PGHOST'], dbname=os.environ['PGDATABASE'],
+        user=os.environ['PGUSER'], password=os.environ['PGPASSWORD'],
+        port=int(os.environ.get('PGPORT', 5432)),
+    )
+
+
+def run_migrations(conn):
+    root = Path(__file__).resolve().parents[2]
+    for sql_file in sorted((root / 'db' / 'strategy_research').glob('*.sql')):
+        with open(sql_file) as f:
+            sql = f.read()
+        for stmt in sql.split(';'):
+            stripped = '\n'.join(
+                line for line in stmt.splitlines()
+                if not line.strip().startswith('--')
+            ).strip()
+            if not stripped:
+                continue
+            try:
+                conn.cursor().execute(stripped)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+    print("Migrations verified.")
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+def load_symbol_ids(conn):
+    cur = conn.cursor()
+    cur.execute("SELECT symbol, id FROM market_data.symbols")
+    return {row[0]: row[1] for row in cur.fetchall()}
+
+
+def load_minute_data(conn, symbol_id):
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT date, (bid_close + ask_close) / 2.0
+        FROM market_data.minute_prices
+        WHERE symbol_id = %s ORDER BY date
+    """, (symbol_id,))
+    rows = cur.fetchall()
+    if not rows:
+        return None
+    df = pd.DataFrame(rows, columns=['date', 'mid_close'])
+    df['date'] = pd.to_datetime(df['date'], utc=True)
+    df = df.set_index('date').sort_index()
+    df['mid_close'] = df['mid_close'].astype(float)
+    return df
+
+
+def load_hourly_data(conn, symbol_id):
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT date, (bid_close + ask_close) / 2.0
+        FROM market_data.hourly_prices
+        WHERE symbol_id = %s ORDER BY date
+    """, (symbol_id,))
+    rows = cur.fetchall()
+    if not rows:
+        return None
+    df = pd.DataFrame(rows, columns=['date', 'mid_close'])
+    df['date'] = pd.to_datetime(df['date'], utc=True)
+    df = df.set_index('date').sort_index()
+    df['mid_close'] = df['mid_close'].astype(float)
+    return df
+
+
+def resample_to_tf(df, rule):
+    return df['mid_close'].resample(rule).last().dropna().to_frame()
+
+
+# ---------------------------------------------------------------------------
+# Features
+# ---------------------------------------------------------------------------
+def compute_features(df, lookback):
+    prices = df['mid_close']
+    mean_n = prices.rolling(lookback).mean()
+    std_n  = prices.rolling(lookback).std(ddof=1)
+    z      = (prices - mean_n) / std_n.replace(0, np.nan)
+    out = df.copy()
+    out['mean_n']  = mean_n
+    out['std_n']   = std_n
+    out['z_score'] = z
+    return out.dropna(subset=['z_score'])
+
+
+def period_label(ts):
+    return 'unseen' if ts >= OOS_CUTOFF else 'in_sample'
+
+
+# ---------------------------------------------------------------------------
+# Backtest — pure numpy loop for speed
+# ---------------------------------------------------------------------------
+def run_backtest(df_feat, threshold):
+    prices    = df_feat['mid_close'].values
+    zscores   = df_feat['z_score'].values
+    timestamps = df_feat.index
+    n = len(df_feat)
+
+    trades = []
+    in_pos = False
+    side   = 0
+    entry_i = 0
+    entry_price = 0.0
+    entry_z = 0.0
+
+    for i in range(n):
+        z = zscores[i]
+        if np.isnan(z):
+            continue
+        p = prices[i]
+
+        if not in_pos:
+            if z < -threshold:
+                in_pos = True; side = 1
+                entry_i = i; entry_price = p; entry_z = z
+            elif z > threshold:
+                in_pos = True; side = -1
+                entry_i = i; entry_price = p; entry_z = z
+        else:
+            if (side == 1 and z >= 0.0) or (side == -1 and z <= 0.0):
+                ret = (p - entry_price) / entry_price * side
+                ts_e = timestamps[entry_i]
+                trades.append((
+                    ts_e.to_pydatetime(),
+                    timestamps[i].to_pydatetime(),
+                    float(entry_price), float(p),
+                    float(entry_z),     float(z),
+                    side, i - entry_i,  float(ret),
+                    period_label(ts_e),
+                ))
+                in_pos = False
+    return trades
+
+
+# ---------------------------------------------------------------------------
+# Analysis helpers
+# ---------------------------------------------------------------------------
+def _sharpe(rets):
+    if len(rets) < 2: return None
+    m = statistics.mean(rets)
+    s = statistics.stdev(rets)
+    return m / s if s > 0 else None
+
+def _median(vals):
+    if not vals: return None
+    s = sorted(vals); n = len(s)
+    return (s[n // 2] + s[(n - 1) // 2]) / 2.0
+
+def _max_dd(rets):
+    cum = peak = mdd = 0.0
+    for r in rets:
+        cum += r
+        if cum > peak: peak = cum
+        if peak - cum > mdd: mdd = peak - cum
+    return mdd
+
+def _payoff(rets):
+    wins  = [r for r in rets if r > 0]
+    loses = [r for r in rets if r < 0]
+    if not wins or not loses: return None
+    return statistics.mean(wins) / abs(statistics.mean(loses))
+
+def trade_stats(trades):
+    if not trades: return None
+    rets = [t[8] for t in trades]
+    bars = [t[7] for t in trades]
+    n    = len(rets)
+    return {
+        'n':      n,
+        'mean':   statistics.mean(rets),
+        'median': _median(rets),
+        'std':    statistics.stdev(rets) if n > 1 else 0.0,
+        'sharpe': _sharpe(rets),
+        'wr':     sum(1 for r in rets if r > 0) / n,
+        'payoff': _payoff(rets),
+        'cum':    sum(rets),
+        'mdd':    _max_dd(rets),
+        'bars':   statistics.mean(bars),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bulk DB writes
+# ---------------------------------------------------------------------------
+TRADE_COLS = ('entry_ts','exit_ts','entry_price','exit_price',
+              'z_at_entry','z_at_exit','side','bars_held','return_pct','period_label')
+
+def bulk_insert_trades(cur, run_id, symbol, tf_label, lb, thr, trades):
+    if not trades:
+        return
+    rows = [(run_id, symbol, tf_label, lb, thr) + t for t in trades]
+    psycopg2.extras.execute_values(cur, """
+        INSERT INTO strategy_research.stat_mr_trades
+            (run_id, symbol, timeframe, lookback, threshold,
+             entry_ts, exit_ts, entry_price, exit_price,
+             z_at_entry, z_at_exit, side, bars_held, return_pct, period_label)
+        VALUES %s ON CONFLICT DO NOTHING
+    """, rows, page_size=5000)
+
+
+def bulk_insert_signals(cur, run_id, symbol, tf_label, lb, thr, trades):
+    if not trades:
+        return
+    rows = [(run_id, symbol, tf_label, lb, thr,
+             t[0], t[6], t[4], t[2], t[9]) for t in trades]
+    psycopg2.extras.execute_values(cur, """
+        INSERT INTO strategy_research.stat_mr_signals
+            (run_id, symbol, timeframe, lookback, threshold,
+             signal_ts, side, z_at_entry, mid_at_entry, period_label)
+        VALUES %s ON CONFLICT DO NOTHING
+    """, rows, page_size=5000)
+
+
+def bulk_insert_features(cur, run_id, symbol, tf_label, lb, df_feat, entry_ts_set):
+    """Store features only at actual entry bars (entries from any threshold)."""
+    rows = []
+    for ts, row in df_feat.iterrows():
+        if ts.to_pydatetime() not in entry_ts_set:
+            continue
+        rows.append((
+            run_id, symbol, tf_label, lb,
+            ts.to_pydatetime(),
+            float(row['mid_close']), float(row['mean_n']),
+            float(row['std_n']),     float(row['z_score']),
+            period_label(ts),
+        ))
+    if rows:
+        psycopg2.extras.execute_values(cur, """
+            INSERT INTO strategy_research.stat_mr_features
+                (run_id, symbol, timeframe, lookback, bar_ts, mid_close,
+                 mean_n, std_n, z_score, period_label)
+            VALUES %s ON CONFLICT DO NOTHING
+        """, rows, page_size=5000)
+
+
+def write_summary(cur, run_id, symbol, tf_label, lb, thr, period, st):
+    if st is None: return
+    cur.execute("""
+        INSERT INTO strategy_research.stat_mr_analysis_summary
+            (run_id, symbol, timeframe, lookback, threshold, period_label,
+             n_trades, mean_return, median_return, std_return, sharpe,
+             win_rate, payoff, cum_return, max_drawdown, avg_bars_held)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ON CONFLICT DO NOTHING
+    """, (run_id, symbol, tf_label, lb, thr, period,
+          st['n'], st['mean'], st['median'], st['std'], st['sharpe'],
+          st['wr'], st['payoff'], st['cum'], st['mdd'], st['bars']))
+
+
+def write_period_cmp(cur, run_id, symbol, tf_label, lb, thr, is_st, oos_st):
+    def v(d, k): return d[k] if d else None
+    n_is  = (is_st['n']  if is_st  else 0) or 0
+    n_oos = (oos_st['n'] if oos_st else 0) or 0
+    sh_is  = v(is_st,  'sharpe'); sh_oos = v(oos_st, 'sharpe')
+    mr_is  = v(is_st,  'mean');   mr_oos = v(oos_st, 'mean')
+    sh_deg = sh_oos / sh_is if sh_is and sh_oos and sh_is != 0 else None
+    mr_deg = mr_oos / mr_is if mr_is and mr_oos and mr_is != 0 else None
+    tc_rat = n_oos / n_is   if n_is > 0 else None
+    cur.execute("""
+        INSERT INTO strategy_research.stat_mr_period_comparison
+            (run_id, symbol, timeframe, lookback, threshold,
+             is_sharpe, oos_sharpe, is_mean_return, oos_mean_return,
+             is_win_rate, oos_win_rate, is_payoff, oos_payoff,
+             is_max_dd, oos_max_dd,
+             sharpe_degradation, return_degradation, trade_count_ratio)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ON CONFLICT DO NOTHING
+    """, (run_id, symbol, tf_label, lb, thr,
+          sh_is, sh_oos, mr_is, mr_oos,
+          v(is_st,'wr'), v(oos_st,'wr'),
+          v(is_st,'payoff'), v(oos_st,'payoff'),
+          v(is_st,'mdd'),  v(oos_st,'mdd'),
+          sh_deg, mr_deg, tc_rat))
+
+
+def write_by_year(cur, run_id, symbol, tf_label, lb, thr, trades):
+    by_yr = defaultdict(list)
+    for t in trades:
+        by_yr[t[0].year].append(t)
+    for yr, yt in sorted(by_yr.items()):
+        st = trade_stats(yt)
+        if not st: continue
+        cur.execute("""
+            INSERT INTO strategy_research.stat_mr_analysis_by_period
+                (run_id, symbol, timeframe, lookback, threshold, period_year,
+                 n_trades, mean_return, sharpe, win_rate, cum_return)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT DO NOTHING
+        """, (run_id, symbol, tf_label, lb, thr, yr,
+              st['n'], st['mean'], st['sharpe'], st['wr'], st['cum']))
+
+
+def write_entry_buckets(cur, run_id, symbol, tf_label, lb, trades):
+    bkts = defaultdict(list)
+    for t in trades:
+        z = abs(t[4]); side = t[6]; pl = t[9]
+        bkt = '1.5-2.0' if z < 2.0 else ('2.0-2.5' if z < 2.5 else ('2.5-3.0' if z < 3.0 else '3.0+'))
+        bkts[(bkt, side, pl)].append(t[8])
+    for (bkt, side, pl), rets in bkts.items():
+        n  = len(rets)
+        wr = sum(1 for r in rets if r > 0) / n
+        mr = statistics.mean(rets)
+        cur.execute("""
+            INSERT INTO strategy_research.stat_mr_analysis_by_entry_bucket
+                (run_id, symbol, timeframe, lookback, period_label, z_bucket, side,
+                 n_trades, mean_return, win_rate)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT DO NOTHING
+        """, (run_id, symbol, tf_label, lb, pl, bkt, side, n, mr, wr))
+
+
+def write_tf_comparison(cur, run_id, symbol, lb, thr, tf_data):
+    # tf_data: list of (tf_label, is_sh, oos_sh, is_n, oos_n, is_wr, oos_wr)
+    is_ranked  = sorted(tf_data, key=lambda x: x[1] if x[1] is not None else -999, reverse=True)
+    oos_ranked = sorted(tf_data, key=lambda x: x[2] if x[2] is not None else -999, reverse=True)
+    for rank, row in enumerate(is_ranked, 1):
+        cur.execute("""
+            INSERT INTO strategy_research.stat_mr_timeframe_comparison
+                (run_id, symbol, lookback, threshold, timeframe, period_label,
+                 sharpe, n_trades, win_rate, tf_rank)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT DO NOTHING
+        """, (run_id, symbol, lb, thr, row[0], 'in_sample',
+              row[1], row[3], row[5], rank))
+    for rank, row in enumerate(oos_ranked, 1):
+        cur.execute("""
+            INSERT INTO strategy_research.stat_mr_timeframe_comparison
+                (run_id, symbol, lookback, threshold, timeframe, period_label,
+                 sharpe, n_trades, win_rate, tf_rank)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT DO NOTHING
+        """, (run_id, symbol, lb, thr, row[0], 'unseen',
+              row[2], row[4], row[6], rank))
+
+
+def write_param_robustness(cur, run_id, symbol, tf_label, period, grid):
+    # grid: {(lb, thr): {sharpe, n}}
+    for (lb, thr), res in grid.items():
+        sh = res.get('sharpe')
+        n  = res.get('n', 0)
+        nbr = []
+        for dlb in [-10, 10]:
+            for dthr in [-0.5, 0.5]:
+                nb = grid.get((lb + dlb, round(thr + dthr, 1)))
+                if nb and nb.get('sharpe') is not None:
+                    nbr.append(nb['sharpe'])
+        nbr_mean = statistics.mean(nbr) if nbr else None
+        stab = (1.0 - abs(sh - nbr_mean) / (abs(sh) + 1e-8)) if (sh is not None and nbr_mean is not None) else None
+        cur.execute("""
+            INSERT INTO strategy_research.stat_mr_param_robustness
+                (run_id, symbol, timeframe, period_label, lookback, threshold,
+                 sharpe, n_trades, neighbor_mean_sharpe, stability_score)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT DO NOTHING
+        """, (run_id, symbol, tf_label, period, lb, thr, sh, n, nbr_mean, stab))
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+def main():
+    conn = connect()
+    run_migrations(conn)
+    cur = conn.cursor()
+
+    run_id = str(uuid.uuid4())
+    config = {
+        'lookbacks':  LOOKBACKS,
+        'thresholds': THRESHOLDS,
+        'timeframes': [t[0] for t in TIMEFRAMES],
+        'symbols':    MINUTE_SYMBOLS,
+        'oos_cutoff': str(OOS_CUTOFF.date()),
+    }
+    cur.execute("""
+        INSERT INTO strategy_research.experiment_runs (run_id, strategy_name, config, notes)
+        VALUES (%s, %s, %s, %s)
+    """, (run_id, 'STAT_MR', json.dumps(config), 'Issue #8 — Baseline Statistical MR'))
+    conn.commit()
+    print(f"Run ID: {run_id}")
+
+    sym_ids = load_symbol_ids(conn)
+
+    for symbol in MINUTE_SYMBOLS:
+        sym_id = sym_ids.get(symbol)
+        if sym_id is None:
+            print(f"  SKIP {symbol}: not in symbols table")
+            continue
+        print(f"\n--- {symbol} ---")
+
+        minute_df = load_minute_data(conn, sym_id)
+        hourly_df = load_hourly_data(conn, sym_id)
+        print(f"  Loaded: {len(minute_df) if minute_df is not None else 0} min "
+              f"/ {len(hourly_df) if hourly_df is not None else 0} hourly")
+
+        # tf_data for timeframe comparison: (tf_label, is_sh, oos_sh, is_n, oos_n, is_wr, oos_wr)
+        tf_compare = defaultdict(lambda: defaultdict(list))
+
+        for tf_label, rule, source in TIMEFRAMES:
+            base_df = (resample_to_tf(minute_df, rule) if source == 'minute' else
+                       (hourly_df.copy() if rule == '1h' else resample_to_tf(hourly_df, rule)))
+            if base_df is None or len(base_df) < max(LOOKBACKS) + 10:
+                continue
+
+            print(f"  {tf_label:<6} bars={len(base_df)}", end='', flush=True)
+
+            # Compute features for each lookback
+            feat_by_lb = {lb: compute_features(base_df, lb) for lb in LOOKBACKS}
+
+            # Collect all entry timestamps for feature storage (FEAT_LOOKBACK only)
+            feat_entries = set()
+
+            grid_is  = {}
+            grid_oos = {}
+
+            for lb in LOOKBACKS:
+                df_feat = feat_by_lb[lb]
+                for thr in THRESHOLDS:
+                    trades = run_backtest(df_feat, thr)
+                    if not trades:
+                        continue
+
+                    is_t  = [t for t in trades if t[9] == 'in_sample']
+                    oos_t = [t for t in trades if t[9] == 'unseen']
+
+                    # Collect entry timestamps for feature storage
+                    if lb == FEAT_LOOKBACK:
+                        feat_entries.update(t[0] for t in trades)
+
+                    bulk_insert_trades( cur, run_id, symbol, tf_label, lb, thr, trades)
+                    bulk_insert_signals(cur, run_id, symbol, tf_label, lb, thr, trades)
+
+                    is_st  = trade_stats(is_t)
+                    oos_st = trade_stats(oos_t)
+                    all_st = trade_stats(trades)
+
+                    write_summary(cur, run_id, symbol, tf_label, lb, thr, 'in_sample', is_st)
+                    write_summary(cur, run_id, symbol, tf_label, lb, thr, 'unseen',    oos_st)
+                    write_summary(cur, run_id, symbol, tf_label, lb, thr, 'combined',  all_st)
+                    write_period_cmp(cur, run_id, symbol, tf_label, lb, thr, is_st, oos_st)
+                    write_by_year(cur, run_id, symbol, tf_label, lb, thr, trades)
+                    write_entry_buckets(cur, run_id, symbol, tf_label, lb, trades)
+
+                    grid_is[(lb, thr)]  = {'sharpe': is_st['sharpe']  if is_st  else None,
+                                           'n':      is_st['n']       if is_st  else 0}
+                    grid_oos[(lb, thr)] = {'sharpe': oos_st['sharpe'] if oos_st else None,
+                                           'n':      oos_st['n']      if oos_st else 0}
+
+                    # For timeframe comparison
+                    tf_compare[(lb, thr)][tf_label] = (
+                        is_st['sharpe']  if is_st  else None,
+                        oos_st['sharpe'] if oos_st else None,
+                        is_st['n']       if is_st  else 0,
+                        oos_st['n']      if oos_st else 0,
+                        is_st['wr']      if is_st  else None,
+                        oos_st['wr']     if oos_st else None,
+                    )
+
+            # Features: only at actual entry bars for FEAT_LOOKBACK
+            bulk_insert_features(cur, run_id, symbol, tf_label,
+                                 FEAT_LOOKBACK, feat_by_lb[FEAT_LOOKBACK], feat_entries)
+
+            write_param_robustness(cur, run_id, symbol, tf_label, 'in_sample', grid_is)
+            write_param_robustness(cur, run_id, symbol, tf_label, 'unseen',    grid_oos)
+
+            n_is_total = sum(v['n'] for v in grid_is.values())
+            print(f"  IS_trades={n_is_total}")
+
+        # Timeframe comparison
+        for (lb, thr), tf_dict in tf_compare.items():
+            tf_data = [
+                (tfl, v[0], v[1], v[2], v[3], v[4], v[5])
+                for tfl, v in tf_dict.items()
+            ]
+            write_tf_comparison(cur, run_id, symbol, lb, thr, tf_data)
+
+        conn.commit()
+        print(f"  Committed.")
+
+    conn.commit()
+    print(f"\nDone. Run ID: {run_id}")
+    _print_summary(conn, run_id)
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+def _print_summary(conn, run_id):
+    cur = conn.cursor()
+    print("\n" + "=" * 70)
+    print("STAT_MR RESULTS SUMMARY")
+    print("=" * 70)
+
+    cur.execute("""
+        SELECT symbol, timeframe, lookback, threshold,
+               sharpe, n_trades, win_rate, mean_return
+        FROM strategy_research.stat_mr_analysis_summary
+        WHERE run_id = %s AND period_label = 'unseen' AND n_trades >= 5
+        ORDER BY sharpe DESC NULLS LAST
+        LIMIT 20
+    """, (run_id,))
+    rows = cur.fetchall()
+    print(f"\nTop 20 combos — unseen Sharpe (n≥5):")
+    print(f"  {'symbol':<12} {'tf':<7} {'lb':>4} {'thr':>5}  {'sh_oos':>7}  {'n':>5}  {'wr':>6}  {'mean':>9}")
+    print("  " + "-" * 68)
+    for r in rows:
+        sh = f"{r[4]:+.3f}" if r[4] is not None else "   —  "
+        print(f"  {r[0]:<12} {r[1]:<7} {r[2]:>4} {r[3]:>5.1f}  {sh:>7}  {r[5]:>5}  {r[6]:.3f}  {r[7]:+.6f}")
+
+    cur.execute("""
+        SELECT
+            COUNT(*) AS n,
+            SUM(CASE WHEN is_sharpe > 0  THEN 1 ELSE 0 END) AS pos_is,
+            SUM(CASE WHEN oos_sharpe > 0 THEN 1 ELSE 0 END) AS pos_oos,
+            AVG(sharpe_degradation) FILTER (WHERE sharpe_degradation IS NOT NULL) AS avg_deg,
+            percentile_cont(0.5) WITHIN GROUP (ORDER BY sharpe_degradation)
+                FILTER (WHERE sharpe_degradation IS NOT NULL) AS med_deg
+        FROM strategy_research.stat_mr_period_comparison
+        WHERE run_id = %s AND is_sharpe IS NOT NULL AND oos_sharpe IS NOT NULL
+    """, (run_id,))
+    r = cur.fetchone()
+    if r and r[0]:
+        print(f"\nPeriod degradation (all combos with both periods):")
+        print(f"  Total combos:               {r[0]}")
+        print(f"  In-sample positive Sharpe:  {r[1]}")
+        print(f"  Unseen positive Sharpe:     {r[2]}")
+        if r[3] is not None: print(f"  Avg Sharpe degradation:     {r[3]:.3f}")
+        if r[4] is not None: print(f"  Median Sharpe degradation:  {r[4]:.3f}")
+
+    cur.execute("""
+        SELECT DISTINCT ON (symbol)
+            symbol, timeframe, lookback, threshold, sharpe, n_trades, win_rate
+        FROM strategy_research.stat_mr_analysis_summary
+        WHERE run_id = %s AND period_label = 'unseen' AND n_trades >= 5
+        ORDER BY symbol, sharpe DESC NULLS LAST
+    """, (run_id,))
+    rows = cur.fetchall()
+    print(f"\nBest unseen combo per symbol:")
+    print(f"  {'symbol':<12} {'tf':<7} {'lb':>4} {'thr':>5}  {'sh_oos':>7}  {'n':>5}  {'wr':>6}")
+    print("  " + "-" * 55)
+    for r in rows:
+        sh = f"{r[4]:+.3f}" if r[4] is not None else "   —  "
+        print(f"  {r[0]:<12} {r[1]:<7} {r[2]:>4} {r[3]:>5.1f}  {sh:>7}  {r[5]:>5}  {r[6]:.3f}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Stage A exploratory research: raw statistical mean reversion across 7 timeframes, 13 symbols, 9 parameter combos
- Fully isolated from CTU/ETD — all outputs in `strategy_research` schema only
- Signal: z-score entry/exit with zero-cross exit; no filters, stops, or regime conditioning

## What was run
- 13 symbols with full historical data (FX majors, AUS200, BTC/USD, BCH/USD, NGAS, XAU/USD)
- 7 timeframes: 5min → 6h
- Parameter grid: lookback ∈ {10,20,30}, threshold ∈ {1.5,2.0,2.5}
- Research split: in-sample < 2025-06-01, unseen ≥ 2025-06-01

## Key results
- 819 total combos across all symbols/timeframes
- In-sample positive Sharpe: 588/819 (72%)
- Unseen positive Sharpe: 622/819 (76%) — signal generalises
- Median Sharpe degradation: 1.059 (unseen slightly outperforms in-sample on median)
- Best unseen: AUD/CHF 6h lb=30 thr=2.5 (Sharpe +1.499, WR=95.7%, n=23)
- Strong unseen signal concentrates in 4h/6h timeframes and higher thresholds (2.5)

## Tables persisted
`strategy_research`: `experiment_runs`, `stat_mr_features`, `stat_mr_signals`, `stat_mr_trades`, `stat_mr_analysis_summary`, `stat_mr_period_comparison`, `stat_mr_timeframe_comparison`, `stat_mr_param_robustness`, `stat_mr_analysis_by_period`, `stat_mr_analysis_by_entry_bucket`

## Test plan
- [x] Runs across all 7 timeframes
- [x] Fully persisted to TimescaleDB strategy_research schema
- [x] IS vs OOS clearly separated by period_label
- [x] No contamination with CTU/ETD/production systems
- [x] All results SQL queryable

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)